### PR TITLE
Add check for STUB and HEADING variables

### DIFF
--- a/src/Px.php
+++ b/src/Px.php
@@ -73,6 +73,9 @@ class Px
       if(!$this->keyword('STUB')) {
         return $this->keyword('HEADING')->values;
       }
+      if(!$this->keyword('HEADING')) {
+        return $this->keyword('STUB')->values;
+      }
       return array_merge($this->keyword('STUB')->values, $this->keyword('HEADING')->values);
     }
 
@@ -204,7 +207,7 @@ class Px
     {
         $list = $this->keywordList($keyword);
         if (empty($list)) {
-            if ($keyword === 'STUB') { return false; }
+            if ($keyword === 'STUB' || $keyword === 'HEADING') { return false; }
             throw new RuntimeException(sprintf('Keyword "%s" does not exist.', $keyword));
         }
 

--- a/src/Px.php
+++ b/src/Px.php
@@ -70,7 +70,10 @@ class Px
      */
     public function variables()
     {
-        return array_merge($this->keyword('STUB')->values, $this->keyword('HEADING')->values);
+      if(!$this->keyword('STUB')) {
+        return $this->keyword('HEADING')->values;
+      }
+      return array_merge($this->keyword('STUB')->values, $this->keyword('HEADING')->values);
     }
 
     /**
@@ -201,6 +204,7 @@ class Px
     {
         $list = $this->keywordList($keyword);
         if (empty($list)) {
+            if ($keyword === 'STUB') { return false; }
             throw new RuntimeException(sprintf('Keyword "%s" does not exist.', $keyword));
         }
 


### PR DESCRIPTION
PC-Axis file format doesn't always contain both 'STUB' and 'HEADING' variables.

From PC-Axis file format documentation: [http://www.scb.se/sv_/PC-Axis/Documentation/PC-Axis-file-format/](http://www.scb.se/sv_/PC-Axis/Documentation/PC-Axis-file-format/)
`At least one of the keywords STUB or HEADING must be included. Usually both are included, as you choose one or several variables for the stub and the heading, respectively.`

In this pull request I modified variable() and keyword() functions to allow reading PC-Axis files in cases where only one of those two variables are present.
